### PR TITLE
harden the typing of the (yargs-produced) argv object + make test-reporting, test-caching global CLI options

### DIFF
--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -3,6 +3,7 @@ import * as fse from 'fs-extra'
 import { createDefaultLogger, Logger } from 'logger'
 import {
   assigningGet,
+  camelizeRecord,
   dumpFile,
   failMe,
   FilesystemStorageClient,
@@ -317,7 +318,7 @@ export function main() {
         'build the code',
         yargs => withBuildOptions(yargs),
         async rawArgv => {
-          const argv = camelizeRec(rawArgv)
+          const argv = camelizeRecord(rawArgv)
           await run({
             dir: argv.dir,
             command: 'build',
@@ -337,7 +338,7 @@ export function main() {
         'run tests',
         yargs => withBuildOptions(yargs),
         async rawArgv => {
-          const argv = camelizeRec(rawArgv)
+          const argv = camelizeRecord(rawArgv)
           const tr = argv.testReporting
           await run({
             dir: argv.dir,
@@ -363,7 +364,7 @@ export function main() {
         'create publishable packages',
         yargs => withBuildOptions(yargs),
         async rawArgv => {
-          const argv = camelizeRec(rawArgv)
+          const argv = camelizeRecord(rawArgv)
           await run({
             dir: argv.dir,
             command: 'pack',
@@ -407,30 +408,4 @@ export function main() {
       .demandCommand(1)
       .parse()
   )
-}
-
-type CamelizeString<T extends PropertyKey, C extends string = ''> = T extends string
-  ? string extends T
-    ? string
-    : T extends `${infer F}-${infer R}`
-    ? CamelizeString<Capitalize<R>, `${C}${F}`>
-    : `${C}${T}`
-  : T
-
-type Camelize<T> = { [K in keyof T as CamelizeString<K>]: T[K] }
-
-function camelizeRec<T extends Record<string, boolean | string | number | unknown>>(rec: T): Camelize<T> {
-  const ret: Record<string, unknown> = {}
-
-  for (const k of Object.keys(rec)) {
-    const parts = k.split('-')
-    if (parts.length === 1) {
-      ret[k] = rec[k]
-      continue
-    }
-
-    ret[parts.map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1))).join('')] = rec[k]
-  }
-
-  return ret as Camelize<T> // eslint-disable-line @typescript-eslint/consistent-type-assertions
 }

--- a/modules/misc/src/camelize-record.ts
+++ b/modules/misc/src/camelize-record.ts
@@ -1,0 +1,27 @@
+type CamelizeString<T extends PropertyKey, C extends string = ''> = T extends string
+  ? string extends T
+    ? string
+    : T extends `${infer F}-${infer R}`
+    ? CamelizeString<Capitalize<R>, `${C}${F}`>
+    : `${C}${T}`
+  : T
+
+export type CamelizeRecord<T> = { [K in keyof T as CamelizeString<K>]: T[K] }
+
+export function camelizeRecord<T extends Record<string, boolean | string | number | unknown>>(
+  rec: T,
+): CamelizeRecord<T> {
+  const ret: Record<string, unknown> = {}
+
+  for (const k of Object.keys(rec)) {
+    const parts = k.split('-')
+    if (parts.length === 1) {
+      ret[k] = rec[k]
+      continue
+    }
+
+    ret[parts.map((p, i) => (i === 0 ? p : p[0].toUpperCase() + p.slice(1))).join('')] = rec[k]
+  }
+
+  return ret as CamelizeRecord<T> // eslint-disable-line @typescript-eslint/consistent-type-assertions
+}

--- a/modules/misc/src/index.ts
+++ b/modules/misc/src/index.ts
@@ -1,4 +1,5 @@
 export * from './arrays'
+export * from './camelize-record'
 export * from './constructs'
 export * from './directory-scanner'
 export * from './executor'

--- a/modules/misc/tests/camelize-record.spec.ts
+++ b/modules/misc/tests/camelize-record.spec.ts
@@ -1,0 +1,29 @@
+import { CamelizeRecord, camelizeRecord } from '../src/camelize-record'
+
+type Example = Record<'first-name' | 'last-name' | 'home-town', string | number | boolean>
+
+describe('camelize-record', () => {
+  test('converts the input record to a similar record where all attribute names were camelCased', () => {
+    const example: Example = {
+      'first-name': 'fn',
+      'home-town': 'ht',
+      'last-name': 'ln',
+    }
+
+    const output = camelizeRecord(example)
+    const explicitlyTypedOutput: CamelizeRecord<Example> = output
+    expect(explicitlyTypedOutput).toEqual({
+      firstName: 'fn',
+      homeTown: 'ht',
+      lastName: 'ln',
+    })
+  })
+})
+
+// Assert that CamelizedRecord produces a type with camel case attribute names. Note that this does not check the sad
+// path (which would be: does not contain attributes which are non-camel-cased) as this would break compilaion.
+const _ignore: CamelizeRecord<Example> = {
+  firstName: 'foo',
+  lastName: 'boo',
+  homeTown: 'zoo',
+}

--- a/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
+++ b/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
@@ -808,7 +808,6 @@ export class YarnRepoProtocol implements RepoProtocol {
       taskName: TaskName(u.id, TaskKind('publish-assets')),
       outputLocations: [{ pathInRepo: dir.expand(PREPARED_ASSETS_DIR), purge: 'NEVER' }],
       inputs: [dir.expand('package.json'), dir.expand(this.dist('s'))],
-      deps: this.depList(TaskName(u.id, TaskKind('test'))),
     }
   }
 

--- a/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
+++ b/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
@@ -808,6 +808,7 @@ export class YarnRepoProtocol implements RepoProtocol {
       taskName: TaskName(u.id, TaskKind('publish-assets')),
       outputLocations: [{ pathInRepo: dir.expand(PREPARED_ASSETS_DIR), purge: 'NEVER' }],
       inputs: [dir.expand('package.json'), dir.expand(this.dist('s'))],
+      deps: this.depList(TaskName(u.id, TaskKind('test'))),
     }
   }
 


### PR DESCRIPTION
by camelCasing the argv object, we can now transition access to its attributes from `argv['test-reporting']` to `argv.testReporting`. The former allows any string to be specified (at compile time), while the latter will naturally fail (at compile time) if the attribute name is incorrect.
