### PR TITLE
fix yarn workspaces info parsing failure when build-raptor run is invoked from a yarn script

### DIFF
--- a/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
+++ b/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
@@ -706,9 +706,19 @@ export class YarnRepoProtocol implements RepoProtocol {
     const p = await execa('yarn', ['--silent', 'workspaces', 'info', '--json'], {
       cwd: rootDir.resolve(),
       reject: false,
+      encoding: 'utf-8',
+      extendEnv: false,
+      env: {},
     })
     if (p.exitCode === 0) {
-      const parsed = JSON.parse(p.stdout)
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(p.stdout)
+      } catch (e) {
+        this.logger.info(`unparsable output of yarn workspaces info: <${p.stdout}>`)
+        throw new Error(`could not parse yarn workspaces info`)
+      }
+
       return yarnWorkspacesInfoSchema.parse(parsed)
     }
 

--- a/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
+++ b/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
@@ -706,7 +706,8 @@ export class YarnRepoProtocol implements RepoProtocol {
     const copy: NodeJS.ProcessEnv = {}
     // eslint-disable-next-line no-process-env
     for (const [k, v] of Object.entries(process.env)) {
-      // FORCE_COLOR makes yarn return colored output and then JSON.parse() fails
+      // FORCE_COLOR makes yarn return colored output and then JSON.parse() fails. Ideally we'd want to pass an empty
+      // env to any process we spawn, but some of the CI systems rely on env vars being set.
       if (k === 'FORCE_COLOR') {
         continue
       }

--- a/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
+++ b/modules/yarn-repo-protocol/src/yarn-repo-protocol.ts
@@ -706,6 +706,7 @@ export class YarnRepoProtocol implements RepoProtocol {
     const copy: NodeJS.ProcessEnv = {}
     // eslint-disable-next-line no-process-env
     for (const [k, v] of Object.entries(process.env)) {
+      // FORCE_COLOR makes yarn return colored output and then JSON.parse() fails
       if (k === 'FORCE_COLOR') {
         continue
       }


### PR DESCRIPTION
the FORCE_COLOR env. var makes yarn return colored output which leads to a JSON parsing error