### PR TITLE
iterate on the new task reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
           yarn --version
       - name: install
         run: yarn --frozen-lockfile
-      - name: build and test
+      - name: BUILD & TEST
         run: |
           yarn test --concurrency 4
         env:

--- a/modules/build-raptor-core/src/step-by-step-transmitter.ts
+++ b/modules/build-raptor-core/src/step-by-step-transmitter.ts
@@ -7,53 +7,52 @@ import * as util from 'util'
 export class StepByStepTransmitter {
   private readonly steps: Step[] = []
   private readonly promises: Promise<void>[] = []
+  private readonly stepByStepProcessors: StepByStepProcessor[] = []
+  private stepByStepFile: string | undefined = undefined
 
-  private constructor(
-    private readonly stepByStepFile: string,
-    private readonly stepByStepProcessor: StepByStepProcessor | undefined,
-    private readonly logger: Logger,
-  ) {}
+  constructor(private readonly logger: Logger) {}
+
+  setOutputFile(f: string) {
+    this.stepByStepFile = f
+  }
+
+  addProcessor(p: StepByStepProcessor) {
+    this.stepByStepProcessors.push(p)
+  }
 
   transmit(step: Step) {
     const parsed = Step.parse(step)
     this.steps.push(parsed)
 
-    if (this.stepByStepProcessor) {
-      this.promises.push(Promise.resolve(this.stepByStepProcessor(parsed)))
+    for (const p of this.stepByStepProcessors) {
+      this.promises.push(Promise.resolve(p(parsed)))
     }
   }
 
   async close() {
     await Promise.all(this.promises)
+    if (!this.stepByStepFile) {
+      return
+    }
     const parsed = StepByStep.parse(this.steps)
     fs.writeFileSync(this.stepByStepFile, JSON.stringify(parsed))
     this.logger.info(`step by step written to ${this.stepByStepFile}`)
   }
 
-  static async create(
-    stepByStepFile: string,
-    stepByStepProcessorModuleName: string | undefined,
-    logger: Logger,
-    lookFor = 'processor',
-  ) {
-    let processor
-    if (stepByStepProcessorModuleName) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      const imported = loadDynamically(stepByStepProcessorModuleName) as object
-      const temp = Object.entries(imported)
-        .flatMap(([k, v]) => (k === lookFor ? [v] : []))
-        .find(Boolean)
-      if (!temp) {
-        throw new Error(
-          `could not find ${lookFor} in module ${stepByStepProcessorModuleName} which exports ${util.inspect(
-            imported,
-          )}`,
-        )
-      }
-      processor = temp as StepByStepProcessor // eslint-disable-line @typescript-eslint/consistent-type-assertions
+  async dynamicallyLoadProcessor(stepByStepProcessorModuleName: string, lookFor = 'processor') {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    const imported = loadDynamically(stepByStepProcessorModuleName) as object
+    const temp = Object.entries(imported)
+      .flatMap(([k, v]) => (k === lookFor ? [v] : []))
+      .find(Boolean)
+    if (!temp) {
+      throw new Error(
+        `could not find ${lookFor} in module ${stepByStepProcessorModuleName} which exports ${util.inspect(imported)}`,
+      )
     }
+    const processor = temp as StepByStepProcessor // eslint-disable-line @typescript-eslint/consistent-type-assertions
 
-    logger.info(`processor=${util.inspect(processor)}`)
-    return new StepByStepTransmitter(stepByStepFile, processor, logger)
+    this.logger.info(`processor=${util.inspect(processor)}`)
+    this.addProcessor(processor)
   }
 }

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -244,6 +244,7 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
   } else {
     shouldNeverHappen(tr)
   }
+  printPassing = false
 
   function indent(prevKey: string[], key: string[]) {
     let indent = '|    '

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -367,6 +367,7 @@ export function main() {
         demandOption: false,
         default: 8,
       })
+      // TODO(imaman): seems like --compact, --loudness can be replaced by --task-progress-output
       .options('compact', {
         describe: 'whether to list only executing tasks (i.e., do not print skipped tasks)',
         type: 'boolean',

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -1,3 +1,6 @@
+//     "build": "build-raptor build --compact",
+//      "test": "export NODE_OPTIONS=--no-experimental-fetch && build-raptor test --compact --test-reporting=tree"
+
 import { DefaultAssetPublisher, EngineBootstrapper, findRepoDir, TaskSelector } from 'build-raptor-core'
 import * as fse from 'fs-extra'
 import { createDefaultLogger, Criticality, Logger } from 'logger'

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -239,15 +239,15 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
     return
   }
 
-  let printPassing
+  let renderPassngTests
   if (tr === 'tree') {
-    printPassing = true
+    renderPassngTests = true
   } else if (tr === 'tree-just-failing') {
-    printPassing = false
+    renderPassngTests = false
   } else {
     shouldNeverHappen(tr)
   }
-  printPassing = false
+  // printPassing = false
 
   function indent(prevKey: string[], key: string[]) {
     let indent = '|    '
@@ -301,7 +301,7 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
   const list = Object.entries(groupBy(arr, at => at.fileName)).map(([fileName, tests]) => ({ fileName, tests }))
   const sorted = sortBy(list, at => at.fileName)
   const passing = sorted.filter(at => isPassing(at.tests))
-  if (printPassing) {
+  if (renderPassngTests) {
     for (const at of passing) {
       logger.print(`✅ PASSED ${at.fileName}`, 'high')
     }

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -1,6 +1,3 @@
-//     "build": "build-raptor build --compact",
-//      "test": "export NODE_OPTIONS=--no-experimental-fetch && build-raptor test --compact --test-reporting=tree"
-
 import { DefaultAssetPublisher, EngineBootstrapper, findRepoDir, TaskSelector } from 'build-raptor-core'
 import * as fse from 'fs-extra'
 import { createDefaultLogger, Criticality, Logger } from 'logger'
@@ -187,14 +184,14 @@ export async function run(options: Options) {
 
     reportTests(logger, testOutput.get(arg.taskName) ?? [], options.testReporting ?? 'tree')
 
-    const doPrint =
+    const dumpTaskOutputToTerminal =
       options.printPassing ||
       switchOn(arg.status, {
         CRASH: () => false,
         OK: () => false,
         FAIL: () => true,
       })
-    if (!doPrint) {
+    if (!dumpTaskOutputToTerminal) {
       return
     }
 
@@ -238,6 +235,9 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
   if (tr === 'just-failing') {
     return
   }
+
+  //     "build": "build-raptor build --compact",
+  //      "test": "export NODE_OPTIONS=--no-experimental-fetch && build-raptor test --compact --test-reporting=tree"
 
   let renderPassngTests
   if (tr === 'tree') {
@@ -340,7 +340,7 @@ export function main() {
         default: [],
       })
       .option('print-passing', {
-        describe: 'whether to print the output of passing tasks to the terminal.',
+        describe: 'whether to dump the output of passing tasks to the terminal.',
         type: 'boolean',
         default: false,
       })

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -371,7 +371,7 @@ export function main() {
       .option('test-reporting', {
         choices: ['tree-all', 'tree-just-failing'],
         describe: 'test reporing policy',
-        default: 'tree',
+        default: 'tree-just-failing',
       })
       .option('test-caching', {
         describe: 'whether to skip running tests that have already passed',

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -400,7 +400,7 @@ export function main() {
         default: true,
       })
       .option('task-progress-output', {
-        describe: 'whether to print number of tasks ended/started',
+        describe: 'whether to print a line indicating verdict/execution-type for each task',
         type: 'boolean',
         default: false,
       })

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -239,11 +239,11 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
   //     "build": "build-raptor build --compact",
   //      "test": "export NODE_OPTIONS=--no-experimental-fetch && build-raptor test --compact --test-reporting=tree"
 
-  let renderPassngTests
+  let renderPassingTests
   if (tr === 'tree') {
-    renderPassngTests = true
+    renderPassingTests = true
   } else if (tr === 'tree-just-failing') {
-    renderPassngTests = false
+    renderPassingTests = false
   } else {
     shouldNeverHappen(tr)
   }
@@ -301,7 +301,7 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
   const list = Object.entries(groupBy(arr, at => at.fileName)).map(([fileName, tests]) => ({ fileName, tests }))
   const sorted = sortBy(list, at => at.fileName)
   const passing = sorted.filter(at => isPassing(at.tests))
-  if (renderPassngTests) {
+  if (renderPassingTests) {
     for (const at of passing) {
       logger.print(`✅ PASSED ${at.fileName}`, 'high')
     }

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -25,7 +25,7 @@ import { YarnRepoProtocol } from 'yarn-repo-protocol'
 
 import { TaskExecutionVisualizer } from './task-execution-visualizer'
 
-type TestReporting = 'tree' | 'tree-just-failing'
+type TestReporting = 'tree-all' | 'tree-just-failing'
 
 interface Options {
   units: string[]
@@ -182,7 +182,7 @@ export async function run(options: Options) {
       stream.end()
     }
 
-    reportTests(logger, testOutput.get(arg.taskName) ?? [], options.testReporting ?? 'tree')
+    reportTests(logger, testOutput.get(arg.taskName) ?? [], options.testReporting ?? 'tree-all')
 
     const dumpTaskOutputToTerminal =
       options.printPassing ||
@@ -236,7 +236,7 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
   //      "test": "export NODE_OPTIONS=--no-experimental-fetch && build-raptor test --compact --test-reporting=tree"
 
   let renderPassingTests
-  if (tr === 'tree') {
+  if (tr === 'tree-all') {
     renderPassingTests = true
   } else if (tr === 'tree-just-failing') {
     renderPassingTests = false
@@ -369,7 +369,7 @@ export function main() {
         demandOption: false,
       })
       .option('test-reporting', {
-        choices: ['tree', 'tree-just-failing'],
+        choices: ['tree-all', 'tree-just-failing'],
         describe: 'test reporing policy',
         default: 'tree',
       })
@@ -420,7 +420,9 @@ export function main() {
             criticality: stringToLoudness(argv.loudness),
             testCaching: argv.testCaching,
             testReporting:
-              tr === 'tree' || tr === 'tree-just-failing' || tr === undefined ? tr : failMe(`unsupported value: ${tr}`),
+              tr === 'tree-all' || tr === 'tree-just-failing' || tr === undefined
+                ? tr
+                : failMe(`unsupported value: ${tr}`),
             stepByStepProcessor: argv.stepByStepProcessor,
             buildRaptorConfigFile: argv.configFile,
             taskProgressOutput: argv.taskProgressOutput,
@@ -465,7 +467,9 @@ export function main() {
             criticality: stringToLoudness(argv.loudness),
             testCaching: argv.testCaching,
             testReporting:
-              tr === 'tree' || tr === 'tree-just-failing' || tr === undefined ? tr : failMe(`unsupported value: ${tr}`),
+              tr === 'tree-all' || tr === 'tree-just-failing' || tr === undefined
+                ? tr
+                : failMe(`unsupported value: ${tr}`),
             stepByStepProcessor: argv.stepByStepProcessor,
             buildRaptorConfigFile: argv.configFile,
             taskProgressOutput: argv.taskProgressOutput,

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -121,6 +121,8 @@ export async function run(options: Options) {
 
   // TODO(imaman): use a writable stream?
   const allTestsFile = path.join(buildRaptorDir, 'all-tests')
+
+  // Wipe out the file
   fs.writeFileSync(allTestsFile, '')
 
   let atLeastOneTest = false
@@ -247,9 +249,6 @@ export async function run(options: Options) {
 }
 
 function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting, allTasksFile: string) {
-  //     "build": "build-raptor build --compact",
-  //      "test": "export NODE_OPTIONS=--no-experimental-fetch && build-raptor test --compact --test-reporting=tree"
-
   let renderPassingTests
   if (tr === 'tree-all') {
     renderPassingTests = true
@@ -258,7 +257,6 @@ function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting, a
   } else {
     shouldNeverHappen(tr)
   }
-  // printPassing = false
 
   function indent(prevKey: string[], key: string[]) {
     let indent = '|    '

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -25,7 +25,7 @@ import { YarnRepoProtocol } from 'yarn-repo-protocol'
 
 import { TaskExecutionVisualizer } from './task-execution-visualizer'
 
-type TestReporting = 'just-failing' | 'tree' | 'tree-just-failing'
+type TestReporting = 'tree' | 'tree-just-failing'
 
 interface Options {
   units: string[]
@@ -232,10 +232,6 @@ export async function run(options: Options) {
 }
 
 function reportTests(logger: Logger, arr: TestEndedEvent[], tr: TestReporting) {
-  if (tr === 'just-failing') {
-    return
-  }
-
   //     "build": "build-raptor build --compact",
   //      "test": "export NODE_OPTIONS=--no-experimental-fetch && build-raptor test --compact --test-reporting=tree"
 
@@ -373,7 +369,7 @@ export function main() {
         demandOption: false,
       })
       .option('test-reporting', {
-        choices: ['just-failing', 'tree', 'tree-just-failing'],
+        choices: ['tree', 'tree-just-failing'],
         describe: 'test reporing policy',
         default: 'tree',
       })
@@ -424,9 +420,7 @@ export function main() {
             criticality: stringToLoudness(argv.loudness),
             testCaching: argv.testCaching,
             testReporting:
-              tr === 'just-failing' || tr === 'tree' || tr === 'tree-just-failing' || tr === undefined
-                ? tr
-                : failMe(`unsupported value: ${tr}`),
+              tr === 'tree' || tr === 'tree-just-failing' || tr === undefined ? tr : failMe(`unsupported value: ${tr}`),
             stepByStepProcessor: argv.stepByStepProcessor,
             buildRaptorConfigFile: argv.configFile,
             taskProgressOutput: argv.taskProgressOutput,
@@ -471,9 +465,7 @@ export function main() {
             criticality: stringToLoudness(argv.loudness),
             testCaching: argv.testCaching,
             testReporting:
-              tr === 'just-failing' || tr === 'tree' || tr === 'tree-just-failing' || tr === undefined
-                ? tr
-                : failMe(`unsupported value: ${tr}`),
+              tr === 'tree' || tr === 'tree-just-failing' || tr === undefined ? tr : failMe(`unsupported value: ${tr}`),
             stepByStepProcessor: argv.stepByStepProcessor,
             buildRaptorConfigFile: argv.configFile,
             taskProgressOutput: argv.taskProgressOutput,

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -157,11 +157,14 @@ export async function run(options: Options) {
     }
 
     if (s.step === 'BUILD_RUN_ENDED') {
-      const line = visualizer?.summary(Date.now() - t0)
-      if (atLeastOneTest) {
-        logger.print(`.\n.\n.\nAll test logs were written to ${allTestsFile}\n\n${line ?? ''}`)
-      } else if (line) {
-        logger.print(`.\n.\n.\n${line}`)
+      // If there are no tests, don't print the message asbout the location of the all-test-logs file.
+      // If there is no summary message, do not print it.
+      // If one of them is printed, add a prefix of three blank lines
+      const line = visualizer?.summary(Date.now() - t0) ?? ''
+      const whereIsTheLogMessage = atLeastOneTest ? `All test logs were written to ${allTestsFile}\n\n` : ``
+      if (whereIsTheLogMessage || line) {
+        // The logger does .trim() on the message so we use "." instead of a "pure" blank line
+        logger.print(`.\n.\n.\n${whereIsTheLogMessage}${line}`)
       }
       return
     }

--- a/modules/build-raptor/src/task-execution-visualizer.ts
+++ b/modules/build-raptor/src/task-execution-visualizer.ts
@@ -88,13 +88,8 @@ export class TaskExecutionVisualizer {
 
   summary(durationInMillis: number) {
     const tried = this.numExectuted + this.numCached
-    const width = Math.max(
-      this.numSucceeded.toString().length,
-      this.numFailed.toString().length,
-      this.numBlocked.toString().length,
-      this.numExectuted.toString().length,
-      this.numCached.toString().length,
-    )
+    const width = this.all.toString().length
+
     return [
       `.`,
       ``,

--- a/modules/build-raptor/src/task-execution-visualizer.ts
+++ b/modules/build-raptor/src/task-execution-visualizer.ts
@@ -91,9 +91,6 @@ export class TaskExecutionVisualizer {
     const width = this.all.toString().length
 
     return [
-      `.`,
-      ``,
-      ``,
       `Build Summary (${(durationInMillis / 1000).toFixed(1)}s):`,
       `✅ Succeeded:       ${this.numSucceeded.toString().padStart(width)}/${this.all}`,
       this.numFailed > 0 ? `❌ Failed:          ${this.numFailed.toString().padStart(width)}/${this.all}` : undefined,

--- a/modules/build-raptor/src/task-execution-visualizer.ts
+++ b/modules/build-raptor/src/task-execution-visualizer.ts
@@ -5,6 +5,7 @@ export class TaskExecutionVisualizer {
   private numEnded = 0
   private numBlocked = 0
   private numFailed = 0
+  private numSucceeded = 0
   private numExectuted = 0
   private numCached = 0
   private all = 0
@@ -71,7 +72,10 @@ export class TaskExecutionVisualizer {
         ++this.numFailed
         return '❌'
       },
-      OK: () => '✅',
+      OK: () => {
+        ++this.numSucceeded
+        return '✅'
+      },
       UNKNOWN: () => '',
     })
 
@@ -83,15 +87,30 @@ export class TaskExecutionVisualizer {
   }
 
   summary(durationInMillis: number) {
+    const tried = this.numExectuted + this.numCached
+    const width = Math.max(
+      this.numSucceeded.toString().length,
+      this.numFailed.toString().length,
+      this.numBlocked.toString().length,
+      this.numExectuted.toString().length,
+      this.numCached.toString().length,
+    )
     return [
       `.`,
       ``,
-      `Let's wrap it up (${(durationInMillis / 1000).toFixed(1)}s):`,
       ``,
-      `✅ Succeeded: ${this.numEnded}/${this.all}`,
-      `❌ Failed: ${this.numFailed}/${this.all}`,
-      `🗃️  Cache hit: ${this.numCached}/${this.all} (${((100 * this.numCached) / this.all).toFixed(1)}%)`,
-      `⛔ Could not start: ${this.numBlocked}/${this.all}`,
-    ].join('\n')
+      `Build Summary (${(durationInMillis / 1000).toFixed(1)}s):`,
+      `✅ Succeeded:       ${this.numSucceeded.toString().padStart(width)}/${this.all}`,
+      this.numFailed > 0 ? `❌ Failed:          ${this.numFailed.toString().padStart(width)}/${this.all}` : undefined,
+      this.numBlocked > 0 ? `⛔ Could not start: ${this.numBlocked.toString().padStart(width)}/${this.all}` : undefined,
+      ``,
+      `✨ Executed:        ${this.numExectuted.toString().padStart(width)}/${tried}`,
+      `🗃️  Cache hit:       ${this.numCached.toString().padStart(width)}/${tried} (${(
+        (100 * this.numCached) /
+        tried
+      ).toFixed(1)}%)`,
+    ]
+      .filter(at => at !== undefined)
+      .join('\n')
   }
 }

--- a/modules/build-raptor/src/task-execution-visualizer.ts
+++ b/modules/build-raptor/src/task-execution-visualizer.ts
@@ -1,6 +1,17 @@
+import { switchOn } from 'misc'
+
 export class TaskExecutionVisualizer {
   private numStarted = 0
   private numEnded = 0
+  private numBlocked = 0
+  private numFailed = 0
+  private numCached = 0
+  private all = 0
+  private runningTasks: string[] = []
+
+  addTasks(names: string[]) {
+    this.all += names.length
+  }
 
   private getLine(taskName: string, text?: string): string {
     if (text === undefined) {
@@ -12,12 +23,67 @@ export class TaskExecutionVisualizer {
 
   begin(taskName: string): string {
     ++this.numStarted
+    this.runningTasks.push(taskName)
     return this.getLine(taskName)
   }
 
-  ended(taskName: string, verdict: string): string {
+  ended(
+    taskName: string,
+    verdict: 'OK' | 'FAIL' | 'UNKNOWN' | 'CRASH',
+    executionType: 'EXECUTED' | 'CACHED' | 'UNKNOWN' | 'CANNOT_START',
+  ): string | undefined {
+    if (executionType === 'CANNOT_START' || executionType === 'UNKNOWN') {
+      ++this.numBlocked
+      return undefined
+    }
+
     ++this.numEnded
-    const ret = this.getLine(taskName, verdict)
-    return ret
+    const index = this.runningTasks.indexOf(taskName)
+    if (index >= 0) {
+      this.runningTasks.splice(index, 1)
+    }
+    const secondLine = ''
+    // if (this.runningTasks.length) {
+    //   secondLine = `Currently running: ${this.runningTasks[0]}`
+    //   if (this.runningTasks.length >= 2) {
+    //     secondLine += ` (and ${this.runningTasks.length - 1} more)`
+    //   }
+    // }
+
+    const cacheIndicator = switchOn(executionType, {
+      CACHED: () => {
+        ++this.numCached
+        return '🗃️ '
+      },
+      EXECUTED: () => '󠀠✨',
+    })
+
+    const verdictIndicator = switchOn(verdict, {
+      CRASH: () => {
+        ++this.numFailed
+        return '❌'
+      },
+      FAIL: () => {
+        ++this.numFailed
+        return '❌'
+      },
+      OK: () => '✅',
+      UNKNOWN: () => '',
+    })
+
+    const full = `[${this.all}/${this.all}]`.length
+    const progress = `[${this.numEnded}/${this.all}]`
+    return `${progress.padStart(full, '.')} ${verdictIndicator} ${cacheIndicator} ${taskName}${
+      secondLine ? '\n' + ' '.repeat(4 + full) + secondLine : ''
+    }`
+  }
+
+  summary(_durationInMillis: number) {
+    return [
+      `✅ Succeeded: ${this.numEnded}/${this.all}`,
+      `❌ Failed: ${this.numFailed}/${this.all}`,
+      `⛔ Could not start: ${this.numBlocked}/${this.all}`,
+      `🗃️ Cache hit: ${this.numCached}/${this.all}`,
+    ].join('\n')
   }
 }

--- a/modules/build-raptor/src/task-execution-visualizer.ts
+++ b/modules/build-raptor/src/task-execution-visualizer.ts
@@ -9,7 +9,6 @@ export class TaskExecutionVisualizer {
   private numExectuted = 0
   private numCached = 0
   private all = 0
-  private runningTasks: string[] = []
 
   addTasks(names: string[]) {
     this.all += names.length
@@ -25,7 +24,6 @@ export class TaskExecutionVisualizer {
 
   begin(taskName: string): string {
     ++this.numStarted
-    this.runningTasks.push(taskName)
     return this.getLine(taskName)
   }
 
@@ -43,10 +41,6 @@ export class TaskExecutionVisualizer {
     }
 
     ++this.numEnded
-    const index = this.runningTasks.indexOf(taskName)
-    if (index >= 0) {
-      this.runningTasks.splice(index, 1)
-    }
     const cacheIndicator = switchOn(executionType, {
       CACHED: () => {
         ++this.numCached

--- a/modules/build-raptor/src/task-execution-visualizer.ts
+++ b/modules/build-raptor/src/task-execution-visualizer.ts
@@ -5,6 +5,7 @@ export class TaskExecutionVisualizer {
   private numEnded = 0
   private numBlocked = 0
   private numFailed = 0
+  private numExectuted = 0
   private numCached = 0
   private all = 0
   private runningTasks: string[] = []
@@ -55,7 +56,10 @@ export class TaskExecutionVisualizer {
         ++this.numCached
         return '🗃️ '
       },
-      EXECUTED: () => '󠀠✨',
+      EXECUTED: () => {
+        ++this.numExectuted
+        return '󠀠✨'
+      },
     })
 
     const verdictIndicator = switchOn(verdict, {
@@ -78,12 +82,16 @@ export class TaskExecutionVisualizer {
     }`
   }
 
-  summary(_durationInMillis: number) {
+  summary(durationInMillis: number) {
     return [
+      `.`,
+      ``,
+      `Let's wrap it up (${(durationInMillis / 1000).toFixed(1)}s):`,
+      ``,
       `✅ Succeeded: ${this.numEnded}/${this.all}`,
       `❌ Failed: ${this.numFailed}/${this.all}`,
+      `🗃️  Cache hit: ${this.numCached}/${this.all} (${((100 * this.numCached) / this.all).toFixed(1)}%)`,
       `⛔ Could not start: ${this.numBlocked}/${this.all}`,
-      `🗃️ Cache hit: ${this.numCached}/${this.all}`,
     ].join('\n')
   }
 }

--- a/modules/build-raptor/src/task-execution-visualizer.ts
+++ b/modules/build-raptor/src/task-execution-visualizer.ts
@@ -35,6 +35,9 @@ export class TaskExecutionVisualizer {
     executionType: 'EXECUTED' | 'CACHED' | 'UNKNOWN' | 'CANNOT_START',
   ): string | undefined {
     if (executionType === 'CANNOT_START' || executionType === 'UNKNOWN') {
+      // It looks like UNKNOWN cannot really happen once the task is started, so we ignore it.
+      // CANNOT_START can happen but it clutters the output: after a (single) task that failed to build, there can be
+      // long chain of dependent tasks that will be CANNOT_START. printing these tasks will distract the user.
       ++this.numBlocked
       return undefined
     }
@@ -44,14 +47,6 @@ export class TaskExecutionVisualizer {
     if (index >= 0) {
       this.runningTasks.splice(index, 1)
     }
-    const secondLine = ''
-    // if (this.runningTasks.length) {
-    //   secondLine = `Currently running: ${this.runningTasks[0]}`
-    //   if (this.runningTasks.length >= 2) {
-    //     secondLine += ` (and ${this.runningTasks.length - 1} more)`
-    //   }
-    // }
-
     const cacheIndicator = switchOn(executionType, {
       CACHED: () => {
         ++this.numCached
@@ -81,9 +76,7 @@ export class TaskExecutionVisualizer {
 
     const full = `[${this.all}/${this.all}]`.length
     const progress = `[${this.numEnded}/${this.all}]`
-    return `${progress.padStart(full, '.')} ${verdictIndicator} ${cacheIndicator} ${taskName}${
-      secondLine ? '\n' + ' '.repeat(4 + full) + secondLine : ''
-    }`
+    return `${progress.padStart(full, '.')} ${verdictIndicator} ${cacheIndicator} ${taskName}`
   }
 
   summary(durationInMillis: number) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint --max-warnings 0 'modules/*/**/*.{ts,js,json,d.ts}'",
     "pack-all": "yarn build && node --enable-source-maps modules/build-raptor/dist/src/main.js pack",
     "publish-assets": "yarn build && node --enable-source-maps modules/build-raptor/dist/src/main.js publish-assets",
-    "self-build": "yarn build && time -f 'wall time: %Es' node --enable-source-maps modules/build-raptor/dist/src/main.js test --test-reporting=tree",
+    "self-build": "yarn build && time -f 'wall time: %Es' node --enable-source-maps modules/build-raptor/dist/src/main.js test --task-progress-output",
     "sort-package-json": "sort-package-json 'modules/*/package.json' 'package.json'",
     "test": "yarn self-build"
   },


### PR DESCRIPTION
1/ during the build run we print the names of all completed tasks (with emoji to indicate verdict, execution-type), if --`task-progress-output` is `true`
2/ when the run ends we print a few stat lines (succeeded, failed, executed, cached)
3/ `--test-reporting` now has just these two values: `tree-all`, `tree-just-failing` (default)
4/ logs of all tests are now dumped to `.build-raptor/all-tests`

![image](https://github.com/user-attachments/assets/5a3bf53b-9839-4f4f-a038-e05e4a81d65d)


![image](https://github.com/user-attachments/assets/591d9400-1ce2-4de6-9554-22a63eca3260)



