### PR TITLE
--print-timing now defaults to true; drop setting the AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE env. varialbe  - we are already on AWS SDK v3

### DIFF
--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -429,7 +429,7 @@ export function main() {
       .option('print-timing', {
         describe: 'print task timing report at the end (sorted by duration)',
         type: 'boolean',
-        default: false,
+        default: true,
       })
       .command(
         'build',

--- a/modules/build-raptor/src/build-raptor-cli.ts
+++ b/modules/build-raptor/src/build-raptor-cli.ts
@@ -62,7 +62,6 @@ async function createStorageClient() {
 }
 
 async function makeBootstrapper(options: Options) {
-  process.env.AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE = '1' // eslint-disable-line no-process-env
   if (options.compact !== undefined) {
     options.criticality = options.compact ? 'moderate' : 'low'
   }


### PR DESCRIPTION
The codebase already uses AWS SDK v3 (@aws-sdk/client-s3), so the AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE environment variable is no longer needed.